### PR TITLE
Enable echo map to be processed on the data read from serial before log it on file.

### DIFF
--- a/picocom.c
+++ b/picocom.c
@@ -1523,15 +1523,24 @@ loop(void)
                     fatal("read from port failed: %s", strerror(errno));
             } else {
                 int i;
-                char *bmp = &buff_map[0];
-                if ( opts.log_filename )
-                    if ( writen_ni(log_fd, buff_rd, n) < n )
+                char *bmp;
+                int nm;
+                if ( opts.log_filename ) {
+                    bmp = &buff_map[0];
+                    for (i = 0; i < n; i++) {
+                        bmp += do_map(bmp, opts.emap, buff_rd[i]);
+                    }
+                    nm = bmp - buff_map;
+                    if ( writen_ni(log_fd, buff_map, nm) < nm )
                         fatal("write to logfile failed: %s", strerror(errno));
+                }
+
+                bmp = &buff_map[0];
                 for (i = 0; i < n; i++) {
                     bmp += do_map(bmp, opts.imap, buff_rd[i]);
                 }
-                n = bmp - buff_map;
-                if ( writen_ni(STO, buff_map, n) < n )
+                nm = bmp - buff_map;
+                if ( writen_ni(STO, buff_map, nm) < nm )
                     fatal("write to stdout failed: %s", strerror(errno));
             }
         }


### PR DESCRIPTION
I have an equipment that returns line carriage instead of line break, by adjusting the imap I could proper use the terminal, but the log files still was being printed with line carriage corrupting the data.

This path uses the emap to write the received buffer to log in a similar way it does with transmitted buffer.